### PR TITLE
Apply basic flags to CLI (#2)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,22 +7,20 @@ class Decyphr extends Command {
     // add --version flag to show CLI version
     version: flags.version({char: 'v'}),
     help: flags.help({char: 'h'}),
-    // flag with a value (-n, --name=VALUE)
-    name: flags.string({char: 'n', description: 'name to print'}),
-    // flag with no value (-f, --force)
-    force: flags.boolean({char: 'f'}),
+    text: flags.string({char: 't', description: 'Text that you wish to translate'}),
+    new_language_code: flags.string({char: 'l', description: 'Language code of the target language (2-chars)'}),
+    language_code: flags.string({char: 'c', description: 'Language code of the target language (4-chars)'})
   }
 
-  static args = [{name: 'file'}]
+  static args = [{name: 'text'}]
 
   async run() {
     const {args, flags} = this.parse(Decyphr)
 
-    const name = flags.name ?? 'world'
-    this.log(`hello ${name} from ./src/index.ts`)
-    if (args.file && flags.force) {
-      this.log(`you input --force and --file: ${args.file}`)
-    }
+    const text = flags.text;
+    const new_lang = flags.new_language_code;
+    const lang_code = flags.language_code
+    this.log(`So, you want to translate "${text}" from "${lang_code}" to "${new_lang}"`);
   }
 }
 


### PR DESCRIPTION
The command-line interface now accepts three flags - the text, the target language code and the current language code

Closes #2 